### PR TITLE
Adding charge adjustment type

### DIFF
--- a/invoice_item_adjustment_types.go
+++ b/invoice_item_adjustment_types.go
@@ -18,6 +18,9 @@ var AdjustmentTypeCredit AdjustmentType = "Credit"
 // AdjustmentTypeDebit --
 var AdjustmentTypeDebit AdjustmentType = "Debit"
 
+// AdjustmentTypeCharge --
+var AdjustmentTypeCharge AdjustmentType = "Charge"
+
 //InvoiceItemAdjustmentCreatePayload use it when calling Actions.Create endpoint.
 type InvoiceItemAdjustmentCreatePayload struct {
 	// The accounting code for the invoice item. Accounting codes group transactions that contain similar accounting attributes.


### PR DESCRIPTION
I was sure if `AdjustmentTypeDebit` is valid so I left it in. `AdjustmentTypeCharge` is for creating invoice item adjustment objects for a negative invoice line/tax item.